### PR TITLE
Include 'accept' header in JSON requests

### DIFF
--- a/aiobiketrax/api.py
+++ b/aiobiketrax/api.py
@@ -381,6 +381,9 @@ class TraccarApi:
                     self.identity_api.username,
                     self.identity_api.traccar_password,
                 ),
+                headers={
+                    "Accept": "application/json",
+                },
                 params=params,
             )
 
@@ -413,6 +416,9 @@ class TraccarApi:
                     self.identity_api.username,
                     self.identity_api.traccar_password,
                 ),
+                headers={
+                    "Accept": "application/json",
+                },
                 data=data,
                 json=json,
             )
@@ -446,6 +452,9 @@ class TraccarApi:
                     self.identity_api.username,
                     self.identity_api.traccar_password,
                 ),
+                headers={
+                    "Accept": "application/json",
+                },
                 data=data,
                 json=json,
             )


### PR DESCRIPTION
This solves the issue with trips not returning as JSON. It is included in all other requests, except for the WebSocket.

Should fix https://github.com/basilfx/homeassistant-biketrax/issues/107