### PR TITLE
Do not lock aiohttp to specific version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1054,4 +1054,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "7d45f0b0bed94a687e16ef54d1855dbe2311ca938b61e764c60943204ba9bffc"
+content-hash = "07d2a4c84eef46be09ea1e0f757fccbfd1d3a0790da3360e7cb6a40bf80f0d81"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-aiohttp = "3.9.5"
+aiohttp = "^3.9.5"
 auth0-python = "^3.24.0"
 python = "^3.12"
 PyJWT = "^2.8.0"


### PR DESCRIPTION
This should be 3.9.5 or newer, so it does not break when major versions of aiohttp are released.